### PR TITLE
Fix Karras scheduler doesn't start from the actual max to min

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -419,7 +419,7 @@ class KDiffusionSampler:
         if p.sampler_noise_scheduler_override:
             sigmas = p.sampler_noise_scheduler_override(steps)
         elif self.config is not None and self.config.options.get('scheduler', None) == 'karras':
-            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.1, sigma_max=10, device=shared.device)
+            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.03, sigma_max=14.5, device=shared.device)
         else:
             sigmas = self.model_wrap.get_sigmas(steps)
 
@@ -457,7 +457,7 @@ class KDiffusionSampler:
         if p.sampler_noise_scheduler_override:
             sigmas = p.sampler_noise_scheduler_override(steps)
         elif self.config is not None and self.config.options.get('scheduler', None) == 'karras':
-            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.1, sigma_max=10, device=shared.device)
+            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.03, sigma_max=14.5, device=shared.device)
         else:
             sigmas = self.model_wrap.get_sigmas(steps)
 


### PR DESCRIPTION
There is this magical sigma_min / sigma_max for Karras scheduler seems a bit abrupt. Looking deeper into it, I believe that it is best to match the actual sigma max / sigma min used when training the model. That means for Stable Diffusion, it is the sigma at step 999 and at step 1.